### PR TITLE
add async context manager support for the client

### DIFF
--- a/mystbin/client.py
+++ b/mystbin/client.py
@@ -30,8 +30,10 @@ from .utils import require_authentication
 
 if TYPE_CHECKING:
     import datetime
+    from types import TracebackType
 
     from aiohttp import ClientSession
+    from typing_extensions import Self
 
 __all__ = ("Client",)
 
@@ -41,6 +43,17 @@ class Client:
 
     def __init__(self, *, token: str | None = None, session: ClientSession | None = None) -> None:
         self.http: HTTPClient = HTTPClient(token=token, session=session)
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_cls: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None
+    ) -> None:
+        await self.close()
 
     async def close(self) -> None:
         """|coro|


### PR DESCRIPTION
<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Description

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->
this PR defines `__aenter__` and `__aexit__` for the client to support async context manager usage~ state is cleaned up properly after exit. quick example:

```py
import asyncio
import mystbin

async def main():
    async with mystbin.Client() as client:
        paste = await client.create_paste(filename="secret.txt", content="**** ***")

asyncio.run(main())
```

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
- [x] I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org) for this contribution
